### PR TITLE
Avoid use of global parameters and separate program class

### DIFF
--- a/grigoriefflab/protocols/program_ctffind.py
+++ b/grigoriefflab/protocols/program_ctffind.py
@@ -25,6 +25,7 @@
 # *
 # **************************************************************************
 
+import pyworkflow.em as pwem
 import pyworkflow.protocol.params as params
 
 from grigoriefflab import Plugin
@@ -133,6 +134,17 @@ class ProgramCtffind:
         output file of the program execution.
         """
         return convert.parseCtffind4Output(filename)
+
+    def parseOutputAsCtf(self, filename, psdFile=None):
+        """ Parse the output file and build the CTFModel object
+        with the values.
+        """
+        ctf = pwem.CTFModel()
+        convert.readCtfModel(ctf, filename, ctf4=True)
+        if psdFile:
+            ctf.setPsdFile(psdFile)
+
+        return ctf
 
     def _getArgs(self, protocol):
         # Update first the _params dict

--- a/grigoriefflab/protocols/program_ctffind.py
+++ b/grigoriefflab/protocols/program_ctffind.py
@@ -83,7 +83,7 @@ class ProgramCtffind:
 
         form.addParam('resamplePix', params.BooleanParam, default=True,
                       label="Resample micrograph if pixel size too small?",
-                      condition='useCtffind4 and _isNewCtffind4',
+                      condition='isNewCtffind4',
                       help='When the pixel is too small, Thon rings appear very thin '
                            'and near the origin of the spectrum, which can lead to '
                            'suboptimal fitting. This options resamples micrographs to '
@@ -93,7 +93,7 @@ class ProgramCtffind:
         form.addParam('slowSearch', params.BooleanParam, default=True,
                       expertLevel=params.LEVEL_ADVANCED,
                       label="Slower, more exhaustive search?",
-                      condition='useCtffind4 and _isNewCtffind4',
+                      condition='isNewCtffind4',
                       help="From version 4.1.5 to 4.1.8 the slow (more precise) "
                            "search was activated by default because of reports the "
                            "faster 1D search was significantly less accurate "
@@ -103,6 +103,10 @@ class ProgramCtffind:
     @staticmethod
     def getVersion():
         return Plugin.getActiveVersion(CTFFIND4)
+
+    @staticmethod
+    def isNewCtffind4():
+        return ProgramCtffind.getVersion() != V4_0_15
 
     @staticmethod
     def _getProgram():
@@ -129,9 +133,6 @@ class ProgramCtffind:
         output file of the program execution.
         """
         return convert.parseCtffind4Output(filename)
-
-    def _isNewCtffind4(self):
-        return self.getVersion() != V4_0_15
 
     def _getArgs(self, protocol):
         # Update first the _params dict

--- a/grigoriefflab/protocols/program_ctffind.py
+++ b/grigoriefflab/protocols/program_ctffind.py
@@ -1,0 +1,226 @@
+# **************************************************************************
+# *
+# * Authors:     Josue Gomez BLanco (josue.gomez-blanco@mcgill.ca)
+# *              J.M. De la Rosa Trevin (delarosatrevin@scilifelab.se) [2]
+# *
+# * [2] SciLifeLab, Stockholm University
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+
+import pyworkflow.protocol.params as params
+
+from grigoriefflab import Plugin
+from grigoriefflab.constants import (V4_0_15, V4_1_10, CTFFIND, CTFFIND4)
+import grigoriefflab.convert as convert
+
+
+class ProgramCtffind:
+    """
+    Wrapper of Ctffind programs (3 and 4) that will handle parameters definition
+    and also execution of the program with the proper arguments.
+    This class is not a Protocol, but it is related, since it can be used from
+    protocols that perform CTF estimation.
+    """
+    def __init__(self, protocol):
+        self._program = self._getProgram()  # Load program to use
+        self._findPhaseShift = protocol.findPhaseShift.get()
+        self._args, self._params = self._getArgs(protocol)  # Load general arguments
+
+    @classmethod
+    def defineFormParams(cls, form):
+        """ Define some parameters from this program into the given form. """
+        form.addParam('useCtffind4', params.BooleanParam, default=True,
+                      label="Use ctffind4 to estimate the CTF?",
+                      help='If is true, the protocol will use ctffind4 instead of ctffind3')
+        form.addParam('astigmatism', params.FloatParam, default=100.0,
+                      label='Expected (tolerated) astigmatism (A)',
+                      expertLevel=params.LEVEL_ADVANCED,
+                      help='Astigmatism values much larger than this will be penalised '
+                           '(Angstroms; set negative to remove this restraint)',
+                      condition='useCtffind4')
+        form.addParam('findPhaseShift', params.BooleanParam, default=False,
+                      label="Find additional phase shift?", condition='useCtffind4',
+                      help='If the data was collected with phase plate, this will find '
+                           'additional phase shift due to phase plate',
+                      expertLevel=params.LEVEL_ADVANCED)
+
+        group = form.addGroup('Phase shift parameters')
+        group.addParam('minPhaseShift', params.FloatParam, default=0.0,
+                       label="Minimum phase shift (rad)", condition='findPhaseShift',
+                       help='Lower bound of the search for additional phase shift. '
+                            'Phase shift is of scattered electrons relative to '
+                            'unscattered electrons. In radians.',
+                       expertLevel=params.LEVEL_ADVANCED)
+        group.addParam('maxPhaseShift', params.FloatParam, default=3.15,
+                       label="Maximum phase shift (rad)", condition='findPhaseShift',
+                       help='Upper bound of the search for additional phase shift. '
+                            'Phase shift is of scattered electrons relative to '
+                            'unscattered electrons. In radians. '
+                            'Please use value between 0.10 and 3.15',
+                       expertLevel=params.LEVEL_ADVANCED)
+        group.addParam('stepPhaseShift', params.FloatParam, default=0.2,
+                       label="Phase shift search step (rad)", condition='findPhaseShift',
+                       help='Step size for phase shift search (radians)',
+                       expertLevel=params.LEVEL_ADVANCED)
+
+        form.addParam('resamplePix', params.BooleanParam, default=True,
+                      label="Resample micrograph if pixel size too small?",
+                      condition='useCtffind4 and _isNewCtffind4',
+                      help='When the pixel is too small, Thon rings appear very thin '
+                           'and near the origin of the spectrum, which can lead to '
+                           'suboptimal fitting. This options resamples micrographs to '
+                           'a more reasonable pixel size if needed',
+                      expertLevel=params.LEVEL_ADVANCED)
+
+        form.addParam('slowSearch', params.BooleanParam, default=True,
+                      expertLevel=params.LEVEL_ADVANCED,
+                      label="Slower, more exhaustive search?",
+                      condition='useCtffind4 and _isNewCtffind4',
+                      help="From version 4.1.5 to 4.1.8 the slow (more precise) "
+                           "search was activated by default because of reports the "
+                           "faster 1D search was significantly less accurate "
+                           "(thanks Rado Danev & Tim Grant). "
+                           "Set this parameters to *No* to get faster fits.")
+
+    @staticmethod
+    def getVersion():
+        return Plugin.getActiveVersion(CTFFIND4)
+
+    @staticmethod
+    def _getProgram():
+        """ Return the program to be used. """
+        # FIXME: number of threads are used for steps, not for OpenMP, what should we do?
+        # useThreads = self._protocol.numberOfThreads > 1
+        useThreads = False
+        program = 'export OMP_NUM_THREADS=1; '  # FIXME: consider using OpenMPI threads
+        program += Plugin.getProgram(CTFFIND4, useMP=useThreads)
+
+        return program
+
+    def getCommand(self, **kwargs):
+        """ Return the program and arguments to be run.
+        The input keywords argument should contain key-values for
+        one micrograph or group of micrographs.
+        """
+        params = dict(self._params)
+        params.update(kwargs)
+        return self._program, self._args % params
+
+    def parseOutput(self, filename):
+        """ Retrieve defocus U, V and angle from the
+        output file of the program execution.
+        """
+        return convert.parseCtffind4Output(filename)
+
+    def _isNewCtffind4(self):
+        return self.getVersion() != V4_0_15
+
+    def _getArgs(self, protocol):
+        # Update first the _params dict
+        params = protocol.getCtfParamsDict()
+        # Convert digital frequencies to spatial frequencies
+        sampling = params['samplingRate']
+        params['lowRes'] = sampling / params['lowRes']
+        if params['lowRes'] > 50:
+            params['lowRes'] = 50
+        params['highRes'] = sampling / params['highRes']
+        params['step_focus'] = 500.0
+
+        params['astigmatism'] = protocol.astigmatism.get()
+        if self._findPhaseShift:
+            params['phaseShift'] = "yes"
+            params['minPhaseShift'] = protocol.minPhaseShift.get()
+            params['maxPhaseShift'] = protocol.maxPhaseShift.get()
+            params['stepPhaseShift'] = protocol.stepPhaseShift.get()
+        else:
+            params['phaseShift'] = "no"
+        # ctffind >= v4.1.5
+        params['resamplePix'] = "yes" if protocol.resamplePix else "no"
+        params['slowSearch'] = "yes" if protocol.slowSearch else "no"
+
+        downFactor = protocol.ctfDownFactor.get()
+        if downFactor != 1:
+            params['scannedPixelSize'] *= downFactor
+
+        args = """   << eof > %(ctffindOut)s
+%(micFn)s
+%(ctffindPSD)s"""
+        args += self._getExtraArgs()
+        return args, params
+
+    def _getExtraArgs(self):
+        args = """
+%(samplingRate)f
+%(voltage)f
+%(sphericalAberration)f
+%(ampContrast)f
+%(windowSize)d
+%(lowRes)f
+%(highRes)f
+%(minDefocus)f
+%(maxDefocus)f
+%(step_focus)f"""
+        v = self.getVersion()
+        if v in ['4.1.5', '4.1.8', V4_1_10]:
+            if self._findPhaseShift:
+                args += """
+no
+%(slowSearch)s
+yes
+%(astigmatism)f
+%(phaseShift)s
+%(minPhaseShift)f
+%(maxPhaseShift)f
+%(stepPhaseShift)f
+yes
+%(resamplePix)s
+eof
+"""
+            else:
+                args += """
+no
+%(slowSearch)s
+yes
+%(astigmatism)f
+%(phaseShift)s
+yes
+%(resamplePix)s
+eof
+"""
+        elif v == V4_0_15:
+            if self._findPhaseShift:
+                args += """
+%(astigmatism)f
+%(phaseShift)s
+%(minPhaseShift)f
+%(maxPhaseShift)f
+%(stepPhaseShift)f
+eof
+"""
+            else:
+                args += """
+%(astigmatism)f
+%(phaseShift)s
+eof
+"""
+
+        return args
+

--- a/grigoriefflab/protocols/protocol_ctffind.py
+++ b/grigoriefflab/protocols/protocol_ctffind.py
@@ -29,12 +29,9 @@ import os
 import sys
 
 import pyworkflow as pw
-import pyworkflow.protocol.params as params
-
-from grigoriefflab import Plugin
-from grigoriefflab.constants import (V4_0_15, V4_1_10, CTFFIND, CTFFIND4)
-from grigoriefflab.convert import (readCtfModel, parseCtffindOutput,
-                                   parseCtffind4Output)
+import grigoriefflab.convert as convert
+from grigoriefflab.constants import V4_0_15
+from .program_ctffind import ProgramCtffind
 
 
 class ProtCTFFind(pw.em.ProtCTFMicrographs):
@@ -45,7 +42,7 @@ class ProtCTFFind(pw.em.ProtCTFMicrographs):
     To find more information about ctffind4 go to:
     http://grigoriefflab.janelia.org/ctffind4
     """
-    _label = 'ctffind'
+    _label = 'ctffind4'
 
     @classmethod
     def validateInstallation(cls):
@@ -67,62 +64,14 @@ class ProtCTFFind(pw.em.ProtCTFMicrographs):
 
     def _defineParams(self, form):
         pw.em.ProtCTFMicrographs._defineParams(self, form)
-        # Define the streaming parameters at the end
         self._defineStreamingParams(form)
 
     def _defineProcessParams(self, form):
-        form.addParam('useCtffind4', params.BooleanParam, default=True,
-                      label="Use ctffind4 to estimate the CTF?",
-                      help='If is true, the protocol will use ctffind4 instead of ctffind3')
-        form.addParam('astigmatism', params.FloatParam, default=100.0,
-                      label='Expected (tolerated) astigmatism (A)',
-                      expertLevel=params.LEVEL_ADVANCED,
-                      help='Astigmatism values much larger than this will be penalised '
-                           '(Angstroms; set negative to remove this restraint)',
-                      condition='useCtffind4')
-        form.addParam('findPhaseShift', params.BooleanParam, default=False,
-                      label="Find additional phase shift?", condition='useCtffind4',
-                      help='If the data was collected with phase plate, this will find '
-                           'additional phase shift due to phase plate',
-                      expertLevel=params.LEVEL_ADVANCED)
+        ProgramCtffind.defineFormParams(form)
 
-        group = form.addGroup('Phase shift parameters')
-        group.addParam('minPhaseShift', params.FloatParam, default=0.0,
-                       label="Minimum phase shift (rad)", condition='findPhaseShift',
-                       help='Lower bound of the search for additional phase shift. '
-                            'Phase shift is of scattered electrons relative to '
-                            'unscattered electrons. In radians.',
-                       expertLevel=params.LEVEL_ADVANCED)
-        group.addParam('maxPhaseShift', params.FloatParam, default=3.15,
-                       label="Maximum phase shift (rad)", condition='findPhaseShift',
-                       help='Upper bound of the search for additional phase shift. '
-                            'Phase shift is of scattered electrons relative to '
-                            'unscattered electrons. In radians. '
-                            'Please use value between 0.10 and 3.15',
-                       expertLevel=params.LEVEL_ADVANCED)
-        group.addParam('stepPhaseShift', params.FloatParam, default=0.2,
-                       label="Phase shift search step (rad)", condition='findPhaseShift',
-                       help='Step size for phase shift search (radians)',
-                       expertLevel=params.LEVEL_ADVANCED)
-
-        form.addParam('resamplePix', params.BooleanParam, default=True,
-                      label="Resample micrograph if pixel size too small?",
-                      condition='useCtffind4 and _isNewCtffind4',
-                      help='When the pixel is too small, Thon rings appear very thin '
-                           'and near the origin of the spectrum, which can lead to '
-                           'suboptimal fitting. This options resamples micrographs to '
-                           'a more reasonable pixel size if needed',
-                      expertLevel=params.LEVEL_ADVANCED)
-
-        form.addParam('slowSearch', params.BooleanParam, default=True,
-                      expertLevel=params.LEVEL_ADVANCED,
-                      label="Slower, more exhaustive search?",
-                      condition='useCtffind4 and _isNewCtffind4',
-                      help="From version 4.1.5 to 4.1.8 the slow (more precise) "
-                           "search was activated by default because of reports the "
-                           "faster 1D search was significantly less accurate "
-                           "(thanks Rado Danev & Tim Grant). "
-                           "Set this parameters to *No* to get faster fits.")
+    def _defineCtfParamsDict(self):
+        pw.em.ProtCTFMicrographs._defineCtfParamsDict(self)
+        self._ctfProgram = ProgramCtffind(self)
 
     # -------------------------- STEPS functions ------------------------------
     def _estimateCTF(self, mic, *args):
@@ -133,7 +82,6 @@ class ProtCTFFind(pw.em.ProtCTFMicrographs):
             # Create micrograph dir
             pw.utils.makePath(micDir)
             downFactor = self.ctfDownFactor.get()
-            scannedPixelSize = self.inputMicrographs.get().getScannedPixelSize()
             micFnMrc = os.path.join(micDir, pw.utils.replaceBaseExt(micFn, 'mrc'))
 
             ih = pw.em.ImageHandler()
@@ -145,23 +93,19 @@ class ProtCTFFind(pw.em.ProtCTFMicrographs):
                 # Replace extension by 'mrc' because there are some formats
                 # that cannot be written (such as dm3)
                 ih.scaleFourier(micFn, micFnMrc, downFactor)
-                self._params['scannedPixelSize'] = scannedPixelSize * downFactor
             else:
                 ih.convert(micFn, micFnMrc, pw.em.DT_FLOAT)
-
-            # Update _params dictionary
-            self._params['micFn'] = micFnMrc
-            self._params['micDir'] = micDir
-            self._params['ctffindOut'] = self._getCtfOutPath(mic)
-            self._params['ctffindPSD'] = self._getPsdPath(mic)
 
         except Exception as ex:
             print >> sys.stderr, "Some error happened: %s" % ex
             import traceback
             traceback.print_exc()
-
         try:
-            self.runJob(self._program, self._args % self._params)
+            program, args = self._ctfProgram.getCommand(
+                micFn=micFnMrc,
+                ctffindOut=self._getCtfOutPath(mic),
+                ctffindPSD=self._getPsdPath(mic))
+            self.runJob(program, args)
         except Exception as ex:
             print >> sys.stderr, "ctffind has failed with micrograph %s" % micFnMrc
 
@@ -205,7 +149,7 @@ class ProtCTFFind(pw.em.ProtCTFMicrographs):
         psdFile = self._getPsdPath(mic)
 
         ctfModel = pw.em.CTFModel()
-        readCtfModel(ctfModel, out, ctf4=self.useCtffind4.get())
+        convert.readCtfModel(ctfModel, out, ctf4=self.useCtffind4.get())
         ctfModel.setPsdFile(psdFile)
         ctfModel.setMicrograph(mic)
 
@@ -235,51 +179,16 @@ class ProtCTFFind(pw.em.ProtCTFMicrographs):
     def _methods(self):
         if self.inputMicrographs.get() is None:
             return ['Input micrographs not available yet.']
-        methods = "We calculated the CTF of %s using CTFFind. " % self.getObjectTag('inputMicrographs')
+        methods = ("We calculated the CTF of %s using CTFFind. "
+                   % self.getObjectTag('inputMicrographs'))
         methods += self.methodsVar.get('')
         methods += 'Output CTFs: %s' % self.getObjectTag('outputCTF')
 
         return [methods]
 
     # -------------------------- UTILS functions ------------------------------
-    def _getVersionCtffind4(self):
-        return Plugin.getActiveVersion(CTFFIND4)
-
     def _isNewCtffind4(self):
-        return self.useCtffind4 and self._getVersionCtffind4() != V4_0_15
-
-    def _getProgram(self):
-        binaryKey = CTFFIND4 if self.useCtffind4 else CTFFIND
-        useMP = self.numberOfThreads > 1 and not self.useCtffind4
-        return Plugin.getProgram(binaryKey, useMP=useMP)
-
-    def _prepareCommand(self):
-        sampling = self.inputMics.getSamplingRate() * self.ctfDownFactor.get()
-        # Convert digital frequencies to spatial frequencies
-        self._params['sampling'] = sampling
-        self._params['lowRes'] = sampling / self._params['lowRes']
-        if self._params['lowRes'] > 50:
-            self._params['lowRes'] = 50
-        self._params['highRes'] = sampling / self._params['highRes']
-        self._params['step_focus'] = 500.0
-        if not self.useCtffind4:
-            self._argsCtffind3()
-        else:
-            self._params['astigmatism'] = self.astigmatism.get()
-            if self.findPhaseShift:
-                self._params['phaseShift'] = "yes"
-                self._params['minPhaseShift'] = self.minPhaseShift.get()
-                self._params['maxPhaseShift'] = self.maxPhaseShift.get()
-                self._params['stepPhaseShift'] = self.stepPhaseShift.get()
-            else:
-                self._params['phaseShift'] = "no"
-
-            # ctffind >= v4.1.5
-            self._params['resamplePix'] = "yes" if self.resamplePix else "no"
-
-            self._params['slowSearch'] = "yes" if self.slowSearch else "no"
-
-            self._argsCtffind4()
+        return ProgramCtffind.getVersion() != V4_0_15
 
     def _prepareRecalCommand(self, ctfModel):
         line = ctfModel.getObjComment().split()
@@ -317,84 +226,6 @@ class ProtCTFFind(pw.em.ProtCTFMicrographs):
 
             self._params['slowSearch'] = "yes" if self.slowSearch else "no"
 
-            self._argsCtffind4()
-
-    def _argsCtffind3(self):
-        self._program = 'export NATIVEMTZ=kk ; '
-        if self.numberOfThreads.get() > 1:
-            self._program += 'export NCPUS=1 ;'
-        self._program += self._getProgram()
-        self._args = """   << eof > %(ctffindOut)s
-%(micFn)s
-%(ctffindPSD)s
-%(sphericalAberration)f,%(voltage)f,%(ampContrast)f,%(magnification)f,%(scannedPixelSize)f
-%(windowSize)d,%(lowRes)f,%(highRes)f,%(minDefocus)f,%(maxDefocus)f,%(step_focus)f
-eof
-"""
-
-    def _argsCtffind4(self):
-
-        # Avoid threads multiplication
-        # self._program = 'export OMP_NUM_THREADS=%d; ' % self.numberOfThreads.get()
-        self._program = 'export OMP_NUM_THREADS=1; '
-        self._program += self._getProgram()
-        self._args = """ << eof
-%(micFn)s
-%(ctffindPSD)s
-%(sampling)f
-%(voltage)f
-%(sphericalAberration)f
-%(ampContrast)f
-%(windowSize)d
-%(lowRes)f
-%(highRes)f
-%(minDefocus)f
-%(maxDefocus)f
-%(step_focus)f"""
-
-        if self._getVersionCtffind4() in ['4.1.5', '4.1.8', V4_1_10]:
-            if self.findPhaseShift:
-                self._args += """
-no
-%(slowSearch)s
-yes
-%(astigmatism)f
-%(phaseShift)s
-%(minPhaseShift)f
-%(maxPhaseShift)f
-%(stepPhaseShift)f
-yes
-%(resamplePix)s
-eof
-"""
-            else:
-                self._args += """
-no
-%(slowSearch)s
-yes
-%(astigmatism)f
-%(phaseShift)s
-yes
-%(resamplePix)s
-eof
-"""
-        elif self._getVersionCtffind4() == V4_0_15:
-            if self.findPhaseShift:
-                self._args += """
-%(astigmatism)f
-%(phaseShift)s
-%(minPhaseShift)f
-%(maxPhaseShift)f
-%(stepPhaseShift)f
-eof
-"""
-            else:
-                self._args += """
-%(astigmatism)f
-%(phaseShift)s
-eof
-"""
-
     def _getMicExtra(self, mic, suffix):
         """ Return a file in extra direction with root of micFn. """
         return self._getExtraPath(os.path.basename(mic.getFileName()) + suffix)
@@ -409,10 +240,7 @@ eof
         """ Try to find the output estimation parameters
         from filename. It search for a line containing: Final Values.
         """
-        if not self.useCtffind4:
-            return parseCtffindOutput(filename)
-        else:
-            return parseCtffind4Output(filename)
+        return self._ctfProgram.parseOutput(filename)
 
     def _getCTFModel(self, defocusU, defocusV, defocusAngle, psdFile):
         ctf = pw.em.CTFModel()

--- a/grigoriefflab/protocols/protocol_ctffind.py
+++ b/grigoriefflab/protocols/protocol_ctffind.py
@@ -168,8 +168,9 @@ class ProtCTFFind(pw.em.ProtCTFMicrographs):
         return [methods]
 
     # -------------------------- UTILS functions ------------------------------
-    def _isNewCtffind4(self):
-        return ProgramCtffind.getVersion() != V4_0_15
+    def isNewCtffind4(self):
+        # This function is needed because it is used in Form params condition
+        return ProgramCtffind.isNewCtffind4()
 
     def _getRecalCtfParamsDict(self, ctfModel):
         values = map(float, ctfModel.getObjComment().split())

--- a/grigoriefflab/protocols/protocol_ctffind.py
+++ b/grigoriefflab/protocols/protocol_ctffind.py
@@ -126,12 +126,9 @@ class ProtCTFFind(pw.em.ProtCTFMicrographs):
             newSampling = mic.getSamplingRate() * self.ctfDownFactor.get()
             mic.setSamplingRate(newSampling)
 
-        out = self._getCtfOutPath(mic)
-        psdFile = self._getPsdPath(mic)
-
-        ctfModel = pw.em.CTFModel()
-        convert.readCtfModel(ctfModel, out, ctf4=self.useCtffind4.get())
-        ctfModel.setPsdFile(psdFile)
+        psd = self._getPsdPath(mic)
+        ctfModel = self._ctfProgram.parseOutputAsCtf(self._getCtfOutPath(mic),
+                                                     psdFile=psd)
         ctfModel.setMicrograph(mic)
 
         return ctfModel

--- a/grigoriefflab/protocols/protocol_ctffind.py
+++ b/grigoriefflab/protocols/protocol_ctffind.py
@@ -173,7 +173,7 @@ class ProtCTFFind(pw.em.ProtCTFMicrographs):
         values = map(float, ctfModel.getObjComment().split())
         sampling = ctfModel.getMicrograph().getSamplingRate()
         return {
-            'step_focus': 1000.0,  # FIXME: Why is this different than in estimation???
+            'step_focus': 500.0,
             'lowRes': sampling / values[3],
             'highRes': sampling / values[4],
             'minDefocus': min([values[0], values[1]]),
@@ -205,7 +205,7 @@ class ProtCTFFind(pw.em.ProtCTFMicrographs):
 
     def _summary(self):
         summary = pw.em.ProtCTFMicrographs._summary(self)
-        if self.useCtffind4 and self._getVersionCtffind4() == '4.1.5':
+        if self.useCtffind4 and ProgramCtffind.getVersion() == '4.1.5':
             summary.append("NOTE: ctffind4.1.5 finishes correctly (all output "
                            "is generated properly), but returns an error code. "
                            "Disregard error messages until this is fixed."

--- a/grigoriefflab/tests/__init__.py
+++ b/grigoriefflab/tests/__init__.py
@@ -23,11 +23,12 @@
 # *  e-mail address 'scipion@cnb.csic.es'
 # *
 # **************************************************************************
-from test_protocols_grigoriefflab import TestBrandeisBase, TestImportParticles, \
-    TestBrandeisCtffind, TestBrandeisCtffind4, TestBrandeisCtftilt, \
-    TestFrealignRefine, TestFrealignClassify
-from test_protocols_grigoriefflab_magdist import TestMagDistBase, TestMagDist
-from test_protocols_grigoriefflab_movies import TestMoviesBase, TestUnblur, \
-    TestSummovie
+
+from .test_protocols_grigoriefflab import (
+    TestBase, TestImportParticles, TestCtffind4, TestCtftilt,
+    TestFrealignRefine, TestFrealignClassify)
+from .test_protocols_grigoriefflab_magdist import TestMagDistBase, TestMagDist
+from .test_protocols_grigoriefflab_movies import (TestMoviesBase, TestUnblur,
+                                                  TestSummovie)
 
 

--- a/grigoriefflab/tests/test_protocols_grigoriefflab.py
+++ b/grigoriefflab/tests/test_protocols_grigoriefflab.py
@@ -32,7 +32,7 @@ from grigoriefflab import *
 from grigoriefflab.protocols import *
 
 
-class TestBrandeisBase(BaseTest):
+class TestBase(BaseTest):
     @classmethod
     def setData(cls, dataProject='xmipp_tutorial'):
         cls.dataset = DataSet.getDataSet(dataProject)
@@ -180,53 +180,11 @@ class TestImportParticles(BaseTest):
         self.assertTrue(outputParticles.hasAlignmentProj())
 
     
-class TestBrandeisCtffind(TestBrandeisBase):
+class TestCtffind4(TestBase):
     @classmethod
     def setUpClass(cls):
         setupTestProject(cls)
-        TestBrandeisBase.setData()
-        cls.protImport = cls.runImportMicrographBPV(cls.micFn)
-    
-    def testCtffind(self):
-        protCTF = ProtCTFFind(useCtffind4=False)
-        protCTF.inputMicrographs.set(self.protImport.outputMicrographs)
-        protCTF.ctfDownFactor.set(2)
-        protCTF.numberOfThreads.set(4)
-        self.proj.launchProtocol(protCTF, wait=True)
-        self.assertIsNotNone(protCTF.outputCTF,
-                             "SetOfCTF has not been produced.")
-        
-        valuesList = [[23861, 23664, 56],
-                      [22383, 22153, 52.6],
-                      [22716, 22526, 59.1]]
-        for ctfModel, values in izip(protCTF.outputCTF, valuesList):
-            self.assertAlmostEquals(ctfModel.getDefocusU(),values[0], delta=1000)
-            self.assertAlmostEquals(ctfModel.getDefocusV(),values[1], delta=1000)
-            self.assertAlmostEquals(ctfModel.getDefocusAngle(),values[2], delta=5)
-            self.assertAlmostEquals(ctfModel.getMicrograph().getSamplingRate(),
-                                    2.474, delta=0.001)
-
-    def testCtffind2(self):
-        protCTF = ProtCTFFind(useCtffind4=False)
-        protCTF.inputMicrographs.set(self.protImport.outputMicrographs)
-        protCTF.numberOfThreads.set(4)
-        self.proj.launchProtocol(protCTF, wait=True)
-        self.assertIsNotNone(protCTF.outputCTF, "SetOfCTF has not been produced.")
-        
-        valuesList = [[23920, 23499, 57.6], [22231, 21905, 59.3], [22444, 22270, 45.9]]
-        for ctfModel, values in izip(protCTF.outputCTF, valuesList):
-            self.assertAlmostEquals(ctfModel.getDefocusU(),values[0], delta=1000)
-            self.assertAlmostEquals(ctfModel.getDefocusV(),values[1], delta=1000)
-            self.assertAlmostEquals(ctfModel.getDefocusAngle(),values[2], delta=5)
-            self.assertAlmostEquals(ctfModel.getMicrograph().getSamplingRate(),
-                                    1.237, delta=0.001)
-
-
-class TestBrandeisCtffind4(TestBrandeisBase):
-    @classmethod
-    def setUpClass(cls):
-        setupTestProject(cls)
-        TestBrandeisBase.setData()
+        TestBase.setData()
         cls.protImport = cls.runImportMicrographBPV(cls.micFn)
     
     def testCtffind4V1(self):
@@ -262,7 +220,7 @@ class TestBrandeisCtffind4(TestBrandeisBase):
                                     1.237, delta=0.001)
 
 
-class TestBrandeisCtftilt(TestBrandeisBase):
+class TestCtftilt(TestBase):
     @classmethod
     def setUpClass(cls):
         setupTestProject(cls)
@@ -291,13 +249,13 @@ class TestBrandeisCtftilt(TestBrandeisBase):
                                     4.56, delta=0.001)
 
 
-class TestFrealignRefine(TestBrandeisBase):
+class TestFrealignRefine(TestBase):
     @classmethod
     def setUpClass(cls):
         setupTestProject(cls)
         dataProject='grigorieff'
         dataset = DataSet.getDataSet(dataProject)
-        TestBrandeisBase.setData()
+        TestBase.setData()
         particlesPattern = dataset.getFile('particles.sqlite')
         volFn = dataset.getFile('ref_volume.vol')
         cls.protImportPart = cls.runImportParticleGrigorieff(particlesPattern)
@@ -327,13 +285,13 @@ class TestFrealignRefine(TestBrandeisBase):
         self.launchProtocol(frealign)
 
 
-class TestFrealignClassify(TestBrandeisBase):
+class TestFrealignClassify(TestBase):
     @classmethod
     def setUpClass(cls):
         setupTestProject(cls)
         dataProject='grigorieff'
         dataset = DataSet.getDataSet(dataProject)
-        TestBrandeisBase.setData()
+        TestBase.setData()
         particlesPattern = dataset.getFile('particles.sqlite')
         volFn = dataset.getFile('ref_volume.vol')
         cls.protImportPart = cls.runImportParticleGrigorieff(particlesPattern)
@@ -364,4 +322,3 @@ class TestFrealignClassify(TestBrandeisBase):
         frealign.inputParticles.set(self.protImportPart.outputParticles)
         frealign.input3DReference.set(self.protImportVol.outputVolume)
         self.launchProtocol(frealign)
-


### PR DESCRIPTION
This should be reviewer after https://github.com/I2PC/scipion/pull/1956 in the main branch (ctf-params branch there as well).

@azazellochg Could you specially check the use of samplingRate and scannedPixelSize when using ctfDownFactor?

Additionally, a ProgramCtfind class was added with the program logic (to be reused in Tomo CTF)